### PR TITLE
Separate initial value and target value of the get function.

### DIFF
--- a/src/reastorage.ts
+++ b/src/reastorage.ts
@@ -62,7 +62,7 @@ export const reastorage = <T>(
       key,
       compress
     );
-    if (!targetValue) {
+    if (targetValue === null) {
       setStorageItem(window[`${storage}Storage`], key, initialValue, compress);
     } else {
       data = targetValue;

--- a/src/reastorage.ts
+++ b/src/reastorage.ts
@@ -54,23 +54,18 @@ export const reastorage = <T>(
   let listeners = new Set<VoidFunction>();
 
   const get = () => {
-    if (!getInitial) {
-      getInitial = true;
-      const targetValue = getStorageItem(
-        window[`${storage}Storage`],
-        key,
-        compress
-      );
-      if (!targetValue) {
-        setStorageItem(
-          window[`${storage}Storage`],
-          key,
-          initialValue,
-          compress
-        );
-      } else {
-        data = targetValue;
-      }
+    if (getInitial) return data;
+    getInitial = true;
+
+    const targetValue = getStorageItem(
+      window[`${storage}Storage`],
+      key,
+      compress
+    );
+    if (!targetValue) {
+      setStorageItem(window[`${storage}Storage`], key, initialValue, compress);
+    } else {
+      data = targetValue;
     }
     return data;
   };


### PR DESCRIPTION
It is easier to read for me separating the initial value from the target value.

What do you think about this?

and `!targetValue` is also return true even in the intentional false value. I think it just have to check null.